### PR TITLE
Add local gitea docs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -70,6 +70,9 @@ jobs:
           - context: ./sites/apps/gitea.zoo
             dockerfile: Dockerfile
             image: gitea-zoo
+          - context: ./sites/apps/docs.gitea.zoo
+            dockerfile: Dockerfile
+            image: docs-gitea-zoo
           - context: ./sites/apps/analytics.zoo
             dockerfile: Dockerfile
             image: analytics-zoo

--- a/core/SITES.yaml
+++ b/core/SITES.yaml
@@ -33,6 +33,14 @@ sites:
     icon: 🛒
     hasOAuth: false
     onDemand: true
+  - domain: docs.gitea.zoo
+    type: proxy
+    port: "80"
+    service: docs-gitea-zoo
+    description: Local mirror of Gitea documentation
+    icon: 📚
+    hasOAuth: false
+    onDemand: true
   - domain: example.zoo
     type: static
     port: 80
@@ -171,6 +179,8 @@ services:
   caddy:
     hasHealthCheck: true
   coredns:
+    hasHealthCheck: true
+  docs-gitea-zoo:
     hasHealthCheck: true
   excalidraw-zoo:
     hasHealthCheck: true

--- a/core/caddy/Caddyfile
+++ b/core/caddy/Caddyfile
@@ -152,6 +152,29 @@ http://auth.zoo {
     }
 }
 
+docs.gitea.zoo {
+    import logging
+    import performance_zoo
+    
+    route {
+        import proxy_handler docs-gitea-zoo 80
+    }
+}
+
+http://docs.gitea.zoo {
+    import logging
+    
+    # Check if all sites should redirect to HTTPS
+    @all_https_only expression "{$ZOO_ALL_HTTPS_ONLY:false}" == "true"
+    redir @all_https_only https://{host}{uri} permanent
+    
+    import performance_zoo
+    
+    route {
+        import proxy_handler docs-gitea-zoo 80
+    }
+}
+
 excalidraw.zoo {
     import logging
     import performance_zoo

--- a/core/coredns/Corefile
+++ b/core/coredns/Corefile
@@ -61,6 +61,7 @@ zoo:53 {
         {$ZOO_CADDY_IP} analytics.zoo
         {$ZOO_CADDY_IP} auth.zoo
         {$ZOO_CADDY_IP} classifieds.zoo
+        {$ZOO_CADDY_IP} docs.gitea.zoo
         {$ZOO_CADDY_IP} example.zoo
         {$ZOO_CADDY_IP} excalidraw.zoo
         {$ZOO_CADDY_IP} focalboard.zoo

--- a/docker-compose.packages.yaml
+++ b/docker-compose.packages.yaml
@@ -53,6 +53,10 @@ services:
     image: ghcr.io/bgrins/the_zoo/gitea-zoo:${ZOO_IMAGE_TAG:-latest}
     build: !reset
 
+  docs-gitea-zoo:
+    image: ghcr.io/bgrins/the_zoo/docs-gitea-zoo:${ZOO_IMAGE_TAG:-latest}
+    build: !reset
+
   analytics-zoo:
     image: ghcr.io/bgrins/the_zoo/analytics-zoo:${ZOO_IMAGE_TAG:-latest}
     build: !reset

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -572,6 +572,19 @@ services:
     profiles:
       - on-demand
 
+  docs-gitea-zoo:
+    <<: *zoo-common
+    build: ./sites/apps/docs.gitea.zoo
+    labels:
+      - "zoo.domains=docs.gitea.zoo:80"
+      - "zoo.description=Local mirror of Gitea documentation"
+      - "zoo.icon=📚"
+    healthcheck:
+      <<: *zoo-healthcheck
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:80/"]
+    profiles:
+      - on-demand
+
   northwind:
     <<: *zoo-common
     image: phpmyadmin:5.2

--- a/scripts/build-home-zoo.ts
+++ b/scripts/build-home-zoo.ts
@@ -52,6 +52,7 @@ const SYSTEM_DOMAINS = new Set([
   "mail-api.zoo",
   "admin.auth.zoo",
   "auth.zoo",
+  "docs.gitea.zoo",
   "secure.gravatar.com",
 ]);
 

--- a/sites/apps/docs.gitea.zoo/Dockerfile
+++ b/sites/apps/docs.gitea.zoo/Dockerfile
@@ -1,0 +1,44 @@
+FROM node:22-alpine AS build
+
+ARG GITEA_DOCS_REPO=https://gitea.com/gitea/docs.git
+ARG GITEA_DOCS_REF=eb8ade10c72f697dcc05628b9bd8b1a185f5a4c5
+ARG AWESOME_GITEA_REPO=https://gitea.com/gitea/awesome-gitea.git
+ARG AWESOME_GITEA_REF=a2c1cc40de0dfaa83981ab19c7789414aa5ca10a
+
+ENV NODE_OPTIONS=--max-old-space-size=8192
+
+WORKDIR /src
+
+RUN apk add --no-cache git make
+
+RUN git init . \
+    && git remote add origin "${GITEA_DOCS_REPO}" \
+    && git fetch --depth 1 origin "${GITEA_DOCS_REF}" \
+    && git checkout FETCH_HEAD
+
+RUN mkdir -p /tmp/upstream-awesome \
+    && cd /tmp/upstream-awesome \
+    && git init . \
+    && git remote add origin "${AWESOME_GITEA_REPO}" \
+    && git fetch --depth 1 origin "${AWESOME_GITEA_REF}" \
+    && git checkout FETCH_HEAD
+
+RUN cp /tmp/upstream-awesome/README.md docs/awesome.md \
+    && cp /tmp/upstream-awesome/README.md versioned_docs/version-1.22/awesome.md \
+    && cp /tmp/upstream-awesome/README.md versioned_docs/version-1.23/awesome.md \
+    && cp /tmp/upstream-awesome/README.md versioned_docs/version-1.24/awesome.md \
+    && cp /tmp/upstream-awesome/README.md versioned_docs/version-1.25/awesome.md
+
+COPY patch-config.mjs /usr/local/bin/patch-config.mjs
+
+RUN node /usr/local/bin/patch-config.mjs
+
+RUN corepack enable \
+    && pnpm install --frozen-lockfile \
+    && pnpm run build-CSRApi
+
+FROM nginx:1.27-alpine
+
+COPY --from=build /src/build/ /usr/share/nginx/html/
+
+EXPOSE 80

--- a/sites/apps/docs.gitea.zoo/patch-config.mjs
+++ b/sites/apps/docs.gitea.zoo/patch-config.mjs
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+
+const configPath = "/src/docusaurus.config.js";
+let config = fs.readFileSync(configPath, "utf8");
+
+config = config.replaceAll("https://docs.gitea.com", "https://docs.gitea.zoo");
+config = config.replace(/^\s*\[\n\s*"docusaurus-plugin-plausible"[\s\S]*?^\s*\],\n/m, "");
+
+if (!config.includes('url: "https://docs.gitea.zoo"')) {
+  throw new Error("Failed to rewrite docs site URL");
+}
+
+fs.writeFileSync(configPath, config);

--- a/sites/apps/gitea.zoo/data-golden/gitea/templates/base/head_navbar.tmpl
+++ b/sites/apps/gitea.zoo/data-golden/gitea/templates/base/head_navbar.tmpl
@@ -1,0 +1,220 @@
+{{$notificationUnreadCount := 0}}
+{{if and .IsSigned .NotificationUnreadCount}}
+	{{$notificationUnreadCount = call .NotificationUnreadCount ctx}}
+{{end}}
+{{$activeStopwatch := NIL}}
+{{if and .IsSigned EnableTimetracking .GetActiveStopwatch}}
+	{{$activeStopwatch = call .GetActiveStopwatch ctx}}
+{{end}}
+<nav id="navbar" aria-label="{{ctx.Locale.Tr "aria.navbar"}}">
+	<div class="navbar-left">
+		<!-- the logo -->
+		<a class="item" id="navbar-logo" href="{{AppSubUrl}}/" aria-label="{{if .IsSigned}}{{ctx.Locale.Tr "dashboard"}}{{else}}{{ctx.Locale.Tr "home"}}{{end}}">
+			<img width="30" height="30" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{ctx.Locale.Tr "logo"}}" aria-hidden="true">
+		</a>
+
+		<!-- mobile right menu, it must be here because in mobile view, each item is a flex column, the first item is a full row column -->
+		<div class="ui secondary menu navbar-mobile-right only-mobile">
+			{{if $activeStopwatch}}
+			<a id="mobile-stopwatch-icon" class="active-stopwatch item" href="{{$activeStopwatch.IssueLink}}" title="{{ctx.Locale.Tr "active_stopwatch"}}" data-seconds="{{$activeStopwatch.Seconds}}">
+				<div class="tw-relative">
+					{{svg "octicon-stopwatch"}}
+					<span class="header-stopwatch-dot"></span>
+				</div>
+			</a>
+			{{end}}
+			{{if .IsSigned}}
+			<a id="mobile-notifications-icon" class="item" href="{{AppSubUrl}}/notifications" data-tooltip-content="{{ctx.Locale.Tr "notifications"}}" aria-label="{{ctx.Locale.Tr "notifications"}}">
+				<div class="tw-relative">
+					{{svg "octicon-bell"}}
+					<span class="notification_count{{if not $notificationUnreadCount}} tw-hidden{{end}}">{{$notificationUnreadCount}}</span>
+				</div>
+			</a>
+			{{end}}
+			<button class="item ui icon mini button tw-m-0" id="navbar-expand-toggle" aria-label="{{ctx.Locale.Tr "home.nav_menu"}}">{{svg "octicon-three-bars"}}</button>
+		</div>
+
+		<!-- navbar links non-mobile -->
+		{{if and .IsSigned .MustChangePassword}}
+			{{/* No links */}}
+		{{else if .IsSigned}}
+			{{if not ctx.Consts.RepoUnitTypeIssues.UnitGlobalDisabled}}
+				<a class="item{{if .PageIsIssues}} active{{end}}" href="{{AppSubUrl}}/issues">{{ctx.Locale.Tr "issues"}}</a>
+			{{end}}
+			{{if not ctx.Consts.RepoUnitTypePullRequests.UnitGlobalDisabled}}
+				<a class="item{{if .PageIsPulls}} active{{end}}" href="{{AppSubUrl}}/pulls">{{ctx.Locale.Tr "pull_requests"}}</a>
+			{{end}}
+			{{if not (and ctx.Consts.RepoUnitTypeIssues.UnitGlobalDisabled ctx.Consts.RepoUnitTypePullRequests.UnitGlobalDisabled)}}
+				{{if .ShowMilestonesDashboardPage}}
+					<a class="item{{if .PageIsMilestonesDashboard}} active{{end}}" href="{{AppSubUrl}}/milestones">{{ctx.Locale.Tr "milestones"}}</a>
+				{{end}}
+			{{end}}
+			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/repos">{{ctx.Locale.Tr "explore"}}</a>
+		{{else if .IsLandingPageOrganizations}}
+			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/organizations">{{ctx.Locale.Tr "explore"}}</a>
+		{{else}}
+			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/repos">{{ctx.Locale.Tr "explore"}}</a>
+		{{end}}
+
+		{{template "custom/extra_links" .}}
+
+		{{if not .IsSigned}}
+			<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.zoo">{{ctx.Locale.Tr "help"}}</a>
+		{{end}}
+	</div>
+
+	<!-- the full dropdown menus -->
+	<div class="navbar-right">
+		{{if and .IsSigned .MustChangePassword}}
+			<div class="ui dropdown jump item" data-tooltip-content="{{ctx.Locale.Tr "user_profile_and_more"}}">
+				<span class="text">
+					{{ctx.AvatarUtils.Avatar .SignedUser 24 "tw-mr-1"}}
+					<span class="only-mobile">{{.SignedUser.Name}}</span>
+					<span class="not-mobile">{{svg "octicon-triangle-down"}}</span>
+				</span>
+				<div class="menu user-menu">
+					<div class="header">
+						{{ctx.Locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
+					</div>
+
+					<div class="divider"></div>
+					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout">
+						{{svg "octicon-sign-out"}}
+						{{ctx.Locale.Tr "sign_out"}}
+					</a>
+				</div><!-- end content avatar menu -->
+			</div><!-- end dropdown avatar menu -->
+		{{else if .IsSigned}}
+			{{if $activeStopwatch}}
+			<a class="item not-mobile active-stopwatch" href="{{$activeStopwatch.IssueLink}}" title="{{ctx.Locale.Tr "active_stopwatch"}}" data-seconds="{{$activeStopwatch.Seconds}}">
+				<div class="tw-relative">
+					{{svg "octicon-stopwatch"}}
+					<span class="header-stopwatch-dot"></span>
+				</div>
+			</a>
+			{{end}}
+
+			<a class="item not-mobile" href="{{AppSubUrl}}/notifications" data-tooltip-content="{{ctx.Locale.Tr "notifications"}}" aria-label="{{ctx.Locale.Tr "notifications"}}">
+				<div class="tw-relative">
+					{{svg "octicon-bell"}}
+					<span class="notification_count{{if not $notificationUnreadCount}} tw-hidden{{end}}">{{$notificationUnreadCount}}</span>
+				</div>
+			</a>
+
+			<div class="ui dropdown jump item" data-tooltip-content="{{ctx.Locale.Tr "create_new"}}">
+				<span class="text">
+					{{svg "octicon-plus"}}
+					<span class="not-mobile">{{svg "octicon-triangle-down"}}</span>
+					<span class="only-mobile">{{ctx.Locale.Tr "create_new"}}</span>
+				</span>
+				<div class="menu">
+					<a class="item" href="{{AppSubUrl}}/repo/create">
+						{{svg "octicon-plus"}} {{ctx.Locale.Tr "new_repo"}}
+					</a>
+					{{if not .DisableMigrations}}
+						<a class="item" href="{{AppSubUrl}}/repo/migrate">
+							{{svg "octicon-repo-push"}} {{ctx.Locale.Tr "new_migrate"}}
+						</a>
+					{{end}}
+					{{if .SignedUser.CanCreateOrganization}}
+					<a class="item" href="{{AppSubUrl}}/org/create">
+						{{svg "octicon-organization"}} {{ctx.Locale.Tr "new_org"}}
+					</a>
+					{{end}}
+				</div><!-- end content create new menu -->
+			</div><!-- end dropdown menu create new -->
+
+			<div class="ui dropdown jump item" data-tooltip-content="{{ctx.Locale.Tr "user_profile_and_more"}}">
+				<span class="text">
+					{{ctx.AvatarUtils.Avatar .SignedUser 24 "tw-mr-1"}}
+					<span class="only-mobile">{{.SignedUser.Name}}</span>
+					<span class="not-mobile">{{svg "octicon-triangle-down"}}</span>
+				</span>
+				{{/* do not localize it, here it needs the fixed length (width) to make UI comfortable */}}
+				{{if .IsAdmin}}<span class="navbar-profile-admin">admin</span>{{end}}
+				<div class="menu user-menu">
+					<div class="header">
+						{{ctx.Locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>
+					</div>
+
+					<div class="divider"></div>
+					<a class="item" href="{{.SignedUser.HomeLink}}">
+						{{svg "octicon-person"}}
+						{{ctx.Locale.Tr "your_profile"}}
+					</a>
+					{{if not .DisableStars}}
+						<a class="item" href="{{.SignedUser.HomeLink}}?tab=stars">
+							{{svg "octicon-star"}}
+							{{ctx.Locale.Tr "your_starred"}}
+						</a>
+					{{end}}
+					<a class="item" href="{{AppSubUrl}}/notifications/subscriptions">
+						{{svg "octicon-bell"}}
+						{{ctx.Locale.Tr "notification.subscriptions"}}
+					</a>
+					<a class="{{if .PageIsUserSettings}}active {{end}}item" href="{{AppSubUrl}}/user/settings">
+						{{svg "octicon-tools"}}
+						{{ctx.Locale.Tr "your_settings"}}
+					</a>
+					<a class="item" target="_blank" rel="noopener noreferrer" href="https://docs.gitea.zoo">
+						{{svg "octicon-question"}}
+						{{ctx.Locale.Tr "help"}}
+					</a>
+					{{if .IsAdmin}}
+						<div class="divider"></div>
+						<a class="{{if .PageIsAdmin}}active {{end}}item" href="{{AppSubUrl}}/-/admin">
+							{{svg "octicon-server"}}
+							{{ctx.Locale.Tr "admin_panel"}}
+						</a>
+					{{end}}
+
+					<div class="divider"></div>
+					<a class="item link-action" href data-url="{{AppSubUrl}}/user/logout">
+						{{svg "octicon-sign-out"}}
+						{{ctx.Locale.Tr "sign_out"}}
+					</a>
+				</div><!-- end content avatar menu -->
+			</div><!-- end dropdown avatar menu -->
+		{{else}}
+			{{if .ShowRegistrationButton}}
+				<a class="item{{if .PageIsSignUp}} active{{end}}" href="{{AppSubUrl}}/user/sign_up">
+					{{svg "octicon-person"}}
+					<span class="tw-ml-1">{{ctx.Locale.Tr "register"}}</span>
+				</a>
+			{{end}}
+			<a class="item{{if .PageIsSignIn}} active{{end}}" rel="nofollow" href="{{AppSubUrl}}/user/login{{if not .PageIsSignIn}}?redirect_to={{.CurrentURL}}{{end}}">
+				{{svg "octicon-sign-in"}}
+				<span class="tw-ml-1">{{ctx.Locale.Tr "sign_in"}}</span>
+			</a>
+		{{end}}
+	</div><!-- end full right menu -->
+
+	{{if $activeStopwatch}}
+		<div class="active-stopwatch-popup tippy-target">
+			<div class="tw-flex tw-items-center tw-gap-2 tw-p-3">
+				<a class="stopwatch-link tw-flex tw-items-center tw-gap-2 muted" href="{{$activeStopwatch.IssueLink}}">
+					{{svg "octicon-issue-opened" 16}}
+					<span class="stopwatch-issue">{{$activeStopwatch.RepoSlug}}#{{$activeStopwatch.IssueIndex}}</span>
+				</a>
+				<div class="tw-flex tw-gap-1">
+					<form class="stopwatch-commit form-fetch-action" method="post" action="{{$activeStopwatch.IssueLink}}/times/stopwatch/toggle">
+						{{.CsrfTokenHtml}}
+						<button
+							type="submit"
+							class="ui button mini compact basic icon tw-mr-0"
+							data-tooltip-content="{{ctx.Locale.Tr "repo.issues.stop_tracking"}}"
+						>{{svg "octicon-square-fill"}}</button>
+					</form>
+					<form class="stopwatch-cancel form-fetch-action" method="post" action="{{$activeStopwatch.IssueLink}}/times/stopwatch/cancel">
+						{{.CsrfTokenHtml}}
+						<button
+							type="submit"
+							class="ui button mini compact basic icon tw-mr-0"
+							data-tooltip-content="{{ctx.Locale.Tr "repo.issues.cancel_tracking"}}"
+						>{{svg "octicon-trash"}}</button>
+					</form>
+				</div>
+			</div>
+		</div>
+	{{end}}
+</nav>

--- a/sites/apps/gitea.zoo/data-golden/gitea/templates/home.tmpl
+++ b/sites/apps/gitea.zoo/data-golden/gitea/templates/home.tmpl
@@ -1,0 +1,51 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{if .IsSigned}}{{ctx.Locale.Tr "dashboard"}}{{else}}{{ctx.Locale.Tr "home"}}{{end}}" class="page-content home">
+	<div class="tw-mb-8 tw-px-8">
+		<div class="center">
+			<img class="logo" width="220" height="220" src="{{AssetUrlPrefix}}/img/logo.svg" alt="{{ctx.Locale.Tr "logo"}}">
+			<div class="hero">
+				<h1 class="ui icon header title tw-text-balance">
+					{{AppName}}
+				</h1>
+				<h2 class="tw-text-balance">{{ctx.Locale.Tr "startpage.app_desc"}}</h2>
+			</div>
+		</div>
+	</div>
+	<div class="ui stackable middle very relaxed page grid">
+		<div class="eight wide center column">
+			<h1 class="hero ui icon header">
+				{{svg "octicon-flame"}} {{ctx.Locale.Tr "startpage.install"}}
+			</h1>
+			<p class="large tw-text-balance">
+				Browse local examples on <a href="https://gitea.zoo/explore/repos">gitea.zoo</a>, ship with <a href="https://gitea.zoo/charlie/zoo-docker-templates">Zoo Docker Templates</a>, or start from <a href="https://gitea.zoo/alice/hello-zoo">hello-zoo</a>.
+			</p>
+		</div>
+		<div class="eight wide center column">
+			<h1 class="hero ui icon header">
+				{{svg "octicon-device-desktop"}} {{ctx.Locale.Tr "startpage.platform"}}
+			</h1>
+			<p class="large tw-text-balance">
+				{{ctx.Locale.Tr "startpage.platform_desc" "https://go.dev/"}}
+			</p>
+		</div>
+	</div>
+	<div class="ui stackable middle very relaxed page grid">
+		<div class="eight wide center column">
+			<h1 class="hero ui icon header">
+				{{svg "octicon-rocket"}} {{ctx.Locale.Tr "startpage.lightweight"}}
+			</h1>
+			<p class="large tw-text-balance">
+				{{ctx.Locale.Tr "startpage.lightweight_desc"}}
+			</p>
+		</div>
+		<div class="eight wide center column">
+			<h1 class="hero ui icon header">
+				{{svg "octicon-code"}} {{ctx.Locale.Tr "startpage.license"}}
+			</h1>
+			<p class="large tw-text-balance">
+				Explore open source projects on <a href="https://gitea.zoo/explore/repos">gitea.zoo</a> and contribute through repos like <a href="https://gitea.zoo/community/awesome-zoo">community/awesome-zoo</a>.
+			</p>
+		</div>
+	</div>
+</div>
+{{template "base/footer" .}}


### PR DESCRIPTION
Mirror Gitea docs into the zoo and point Gitea help links at docs.gitea.zoo so the experience stays self-contained. Hide the internal docs site from home.zoo while keeping it available from Gitea.


Note: I'm not a huge fan of the following paths that are largely copy and paste, instead it'd be great if we could just add a transform to the regular source. (These are changing the urls to .zoo only):
- sites/apps/gitea.zoo/data-golden/gitea/templates/base/head_navbar.tmpl
- sites/apps/gitea.zoo/data-golden/gitea/templates/home.tmpl


Docs page:
<img width="1157" height="845" alt="image" src="https://github.com/user-attachments/assets/fbe75e9c-b11c-46d2-8186-ca92ae3840b2" />

Fixes the home page links:
<img width="994" height="397" alt="image" src="https://github.com/user-attachments/assets/739bfb2c-e07c-40d0-8e49-fa6581ddc8cf" />

There's still some broken links laying around, but overall interested in if you're open to patches and the approach. :)